### PR TITLE
Downgrade uglifyjs and use SemVer notation - closes #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "license": "MIT",
     "devDependencies": {
         "coffeescript": "^2.4.1",
-        "express": ">=3.11.0",
+        "express": "^4.17.1",
         "shelljs": "0.1.x",
-        "uglify-js": ">=2.6.0"
+        "uglify-js": "^2.8.29"
     },
     "dependencies": {
         "body-parser": "^1.19.0"


### PR DESCRIPTION
The uglifyjs 3 API is incompatible with uglifyjs 2.

Let's downgrade to uglifyjs 2 again to solve the current issues. We need a complete new setup using terser.